### PR TITLE
Refactor _ping module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = 'README.md'
 repository = "https://github.com/Teledyne-Marine/pyread7k"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.8,<4"
 numpy = "^1.20.1"
 geopy = "^2.1.0"
 psutil = "^5.8.0"

--- a/pyread7k/__init__.py
+++ b/pyread7k/__init__.py
@@ -1,4 +1,4 @@
 from ._datablock import DRFBlock
 from ._datarecord import record
-from ._ping import ConcatDataset, Ping, PingDataset, PingType
+from ._ping import ConcatDataset, Ping, PingDataset, PingType, S7KFileReader, S7KReader
 from ._utils import *

--- a/pyread7k/_ping.py
+++ b/pyread7k/_ping.py
@@ -44,7 +44,11 @@ class PingType(Enum):
 
 
 class S7KReader(metaclass=ABCMeta):
-    """Base abstract class of S7K readers"""
+    """
+    Base abstract class of S7K readers
+
+    *Note*: The current S7KReader API is considered unstable and may change in the future.
+    """
 
     @cached_property
     def file_header(self) -> records.FileHeader:

--- a/pyread7k/_ping.py
+++ b/pyread7k/_ping.py
@@ -9,198 +9,224 @@ Expected order of records for a ping:
 7058, 7068, 7070
 
 """
-import math
-from datetime import timedelta
+import bisect
+import sys
+from abc import ABCMeta, abstractmethod
+from datetime import datetime, timedelta
 from enum import Enum
-from functools import cached_property as cached_property_functools
-from typing import List, Optional, Union
+from itertools import chain
+from typing import (
+    Any,
+    BinaryIO,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import geopy
 import numpy as np
 
 from . import _datarecord, records
-from ._utils import (
-    get_record_offsets,
-    read_file_catalog,
-    read_file_header,
-    read_records,
-)
+from ._utils import cached_property, window
 
 
-def cached_property(func):
-    """
-    Fix functools.cached_property using decorator.decorator to preserve
-    docstrings and name.
-    Note that it does not properly preserve type hints!
-    """
-    cached_f = cached_property_functools(func)
-    cached_f.__name__ = func.__name__
-    cached_f.__doc__ = func.__doc__
-    return cached_f
+class PingType(Enum):
+    """ Kinds of pings based on what data they have available """
+
+    BEAMFORMED = 1
+    IQ = 2
+    ANY = 3
 
 
-class LazyMap(dict):
-    """
-    An advanced defaultdict, where the initializer may depend on the key.
-    """
+class S7KReader(metaclass=ABCMeta):
+    """Base abstract class of S7K readers"""
 
-    def __init__(self, initializer, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.initializer = initializer
+    @cached_property
+    def file_header(self) -> records.FileHeader:
+        """Return the file header record for this reader"""
+        return cast(records.FileHeader, self._read_record(7200, 0))
 
-    def __getitem__(self, key):
-        if key not in self:
-            self[key] = self.initializer(key)
-        return super().__getitem__(key)
-
-
-class Manager7k:
-    """
-    Internal class for Pings to share access to a file.
-    """
-
-    def __init__(self, filename):
-        self.filename = filename
-
-        self.fhandle = open(filename, "rb", buffering=0)
-
-        file_header = read_file_header(self.fhandle)
-        self.file_catalog = read_file_catalog(self.fhandle, file_header)
-        self._offsets_for_type = LazyMap(
-            initializer=lambda key: get_record_offsets(key, self.file_catalog)
+    @cached_property
+    def file_catalog(self) -> records.FileCatalog:
+        """Return the file catalog record for this reader"""
+        return cast(
+            records.FileCatalog,
+            self._read_record(7300, self.file_header.catalog_offset),
         )
 
-    def get_pings(self):
+    @cached_property
+    def configuration(self) -> records.Configuration:
+        """Return the configuration record for this reader"""
+        offsets = self._get_offsets(7001)
+        assert len(offsets) == 1
+        return cast(records.Configuration, self._read_record(7001, offsets[0]))
 
-        settings_records = read_records(7000, self.fhandle, self.file_catalog)
-        settings_offsets = get_record_offsets(7000, self.file_catalog)
-        settings_and_offsets = list(zip(settings_records, settings_offsets))
-        pings = [
-            Ping(rec, offset, next_rec, next_off, self)
-            for (rec, offset), (next_rec, next_off) in zip(
-                settings_and_offsets,
-                settings_and_offsets[1:]
-                + [
-                    (None, math.inf),
-                ],
+    def iter_pings(self, include: PingType = PingType.ANY) -> Iterator["Ping"]:
+        """Iterate over Pings. if include argument is not ANY, filter pings by type"""
+        offsets_records = chain(self._iter_offset_records(7000), [None])
+        pings = (
+            Ping(
+                cast(Tuple[int, records.SonarSettings], offset_record),
+                cast(Optional[Tuple[int, records.SonarSettings]], next_offset_record),
+                reader=self,
             )
-        ]
+            for offset_record, next_offset_record in window(offsets_records, 2)
+        )
+        if include == PingType.ANY:
+            return pings
+        if include == PingType.BEAMFORMED:
+            return (p for p in pings if p.has_beamformed)
+        if include == PingType.IQ:
+            return (p for p in pings if p.has_raw_iq)
+        raise NotImplementedError(f"Encountered unknown PingType: {include!r}")
 
-        return pings
-
-    def get_configuration_record(self) -> records.Configuration:
-        record_offsets = self._offsets_for_type[7001]
-        assert len(record_offsets) == 1
-        return self.read_record(7001, record_offsets[0])
-
-    def get_next_record(self, record_type, offset_start, offset_end):
+    def get_first_offset(
+        self, record_type: int, offset_start: int, offset_end: int
+    ) -> Optional[int]:
         """
-        Get the offset and first record of type record_type which has a higher
-        file offset than offset_start.
+        Get the offset of the first record of type record_type which has a
+        file offset between offset_start and offset_end.
         """
-        offset = self.get_next_offset(record_type, offset_start, offset_end)
-        if offset is None:
-            return None
-        return self.read_record(record_type, offset)
+        offsets = self._get_offsets(record_type)
+        i = bisect.bisect_right(offsets, offset_start)
+        return offsets[i] if i < len(offsets) and offsets[i] < offset_end else None
 
-    def get_next_offset(self, record_type, offset_start, offset_end):
+    def read_first_record(
+        self, record_type: int, offset_start: int, offset_end: int
+    ) -> Optional[records.BaseRecord]:
         """
-        Get the offset of type record_type which has a file offset between
+        Read the first record of type record_type which has a file offset between
         offset_start and offset_end.
-
-        The data from a new ping always starts with a 7000 record, and so you
-        can get the offset of a record for a specific ping by searching
-        for an offset higher than the ping's 7000 record, but lower than the
-        next ping's 7000 record.
         """
-        record_offsets = self._offsets_for_type[record_type]
-        next_index = np.searchsorted(record_offsets, offset_start, side="right")
+        offset = self.get_first_offset(record_type, offset_start, offset_end)
+        return self._read_record(record_type, offset) if offset is not None else None
 
-        if next_index == len(record_offsets):
-            # Reached end of offsets without match
-            return None
-        offset = record_offsets[next_index]
-        if offset < offset_end:
-            # No record exists in the interval
-            return offset
-        return None
-
-    def read_record(self, record_type, offset):
+    def read_records_during_ping(
+        self,
+        record_type: int,
+        ping_start: datetime,
+        ping_end: datetime,
+        offset_hint: int,
+    ) -> List[records.BaseRecord]:
         """
-        Read a record from file using a known offset
+        Read all records of record_type which are timestamped in the interval between
+        ping_start and ping_end. An offset_hint is given as an initial offset of a record
+        close to the interval, to be used if it can make the search more efficient.
         """
-        self.fhandle.seek(offset)
-        return _datarecord.record(record_type).read(self.fhandle)
-
-    def get_records_during_ping(self, record_type, ping_start, ping_end, offset_hint):
-        """
-        Reads all records of record_type which are timestamped in the interval.
-
-        Performs a brute-force search starting around the offset_hint. If the
-        hint is good (which it should usually be), this is pretty efficient.
-
-        Records of different types are not guaranteed to be chronological, so
-        we cannot know a specific record interval to search.
-        """
-        record_offsets = self._offsets_for_type[record_type]
-        initial_index = np.searchsorted(record_offsets, offset_hint)
-
-        searching_backward = True
-        searching_forward = True
+        # Performs a brute-force search starting around the offset_hint. If the
+        # hint is good (which it should usually be), this is pretty efficient.
+        #
+        # Records of different types are not guaranteed to be chronological, so
+        # we cannot know a specific record interval to search.
+        read_record = self._read_record
+        offsets = self._get_offsets(record_type)
+        initial_index = bisect.bisect_left(offsets, offset_hint)
 
         # Search forward in file
         forward_records = []
-        index = initial_index
-        while searching_forward:
-            if index == len(record_offsets):
-                # Reached end of file
-                break
-            next_record = self.read_record(record_type, record_offsets[index])
-            if ping_end is not None and next_record.frame.time > ping_end:
+        searching_backward = True
+        for index in range(initial_index, len(offsets)):
+            next_record = read_record(record_type, offsets[index])
+            next_record_time = next_record.frame.time
+            if next_record_time > ping_end:
                 # Reached upper end of interval
-                searching_forward = False
-            elif not next_record.frame.time > ping_start:
+                break
+            elif next_record_time <= ping_start:
                 # Did not yet reach interval, backward search is unnecessary
                 searching_backward = False
             else:
                 forward_records.append(next_record)
-            index += 1
+
+        if not searching_backward:
+            return forward_records
 
         # Search backward in file
         backward_records = []
-        index = initial_index - 1
-        while searching_backward:
-            if index == -1:
-                break  # Reached start of file
-
-            next_record = self.read_record(record_type, record_offsets[index])
-            if next_record.frame.time < ping_start:
+        for index in range(initial_index - 1, -1, -1):
+            next_record = read_record(record_type, offsets[index])
+            next_record_time = next_record.frame.time
+            if next_record_time < ping_start:
                 # Reached lower end of interval
-                searching_backward = False
-            elif ping_end is not None and not next_record.frame.time < ping_end:
+                break
+            elif next_record_time >= ping_end:
                 # Did not yet reach interval
                 pass
             else:
                 backward_records.append(next_record)
-            index -= 1
+
         # Discovered in reverse order, so un-reverse
         backward_records.reverse()
+        backward_records.extend(forward_records)
+        return backward_records
 
-        return backward_records + forward_records
+    def _read_record(self, record_type: int, offset: int) -> records.BaseRecord:
+        """Read a record of record_type at the given offset"""
+        return _datarecord.record(record_type).read(self._get_stream_for_read(offset))
 
-    def __getstate__(self):
+    def _iter_offset_records(
+        self, record_type: int
+    ) -> Iterator[Tuple[int, records.BaseRecord]]:
+        """Generate all the (offset, record) tuples for the given record type"""
+        read_record = _datarecord.record(record_type).read
+        get_stream = self._get_stream_for_read
+        for offset in self._get_offsets(record_type):
+            yield offset, read_record(get_stream(offset))
+
+    def _get_offsets(self, record_type: int) -> Sequence[int]:
+        """Return all the offsets for the given record type"""
+        try:
+            return self.__cached_offsets[record_type]
+        except (AttributeError, KeyError) as ex:
+            offsets: List[int] = []
+            if record_type != 7300:
+                catalog = self.file_catalog
+                offsets.extend(
+                    offset
+                    for offset, rt in zip(catalog.offsets, catalog.record_types)
+                    if rt == record_type
+                )
+            else:
+                # the file catalog does not contain an entry for the 7300 record
+                offsets.append(self.file_header.catalog_offset)
+
+            if isinstance(ex, AttributeError):
+                self.__cached_offsets: Dict[int, Sequence[int]] = {}
+            return self.__cached_offsets.setdefault(record_type, offsets)
+
+    @abstractmethod
+    def _get_stream_for_read(self, offset: int) -> BinaryIO:
+        """Return a byte stream for reading a record at the given offset"""
+
+
+class S7KFileReader(S7KReader):
+    """Reader class for s7k files"""
+
+    def __init__(self, filename: str):
+        self._filename = filename
+        self._fhandle = open(self._filename, "rb", buffering=0)
+
+    def _get_stream_for_read(self, offset: int) -> BinaryIO:
+        self._fhandle.seek(offset)
+        return self._fhandle
+
+    def __getstate__(self) -> Dict[str, Any]:
         """ Remove unpicklable file handle from dict before pickling. """
         state = self.__dict__.copy()
-        del state["fhandle"]
+        del state["_fhandle"]
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         """ Open new file handle after unpickling. """
         self.__dict__.update(state)
-        self.fhandle = open(self.filename, "rb", buffering=0)
+        self._fhandle = open(self._filename, "rb", buffering=0)
 
-    def __del__(self):
-        self.fhandle.close()
+    def __del__(self) -> None:
+        self._fhandle.close()
 
 
 class Ping:
@@ -209,158 +235,130 @@ class Ping:
     Properties of the ping are loaded efficiently on-demand.
     """
 
-    minimizable_properties = ["beamformed", "tvg", "beam_geometry", "raw_iq"]
-
     def __init__(
         self,
-        settings_record: records.SonarSettings,
-        settings_offset: int,
-        next_record,
-        next_offset: int,
-        manager: Manager7k,
+        offset_record: Tuple[int, records.SonarSettings],
+        next_offset_record: Optional[Tuple[int, records.SonarSettings]],
+        reader: S7KReader,
     ):
-
-        # This is the only record always in-memory, as it defines the ping.
-        self.sonar_settings: records.SonarSettings = settings_record
-        self.ping_number: int = settings_record.ping_number
-
-        self._manager = manager
-        self._own_offset = settings_offset  # This ping's start offset
-        self._next_offset = (
-            next_offset  # Next ping's start offset, meaning this ping has ended
-        )
-        self.next_ping_start = (
-            next_record.frame.time if next_record is not None else None
-        )
-
-        self._offset_map = LazyMap(
-            initializer=lambda key: self._manager.get_next_offset(
-                key, self._own_offset, self._next_offset
-            )
-        )
+        self._reader = reader
+        self._offset, sonar_settings = offset_record
+        self._ping_number = sonar_settings.ping_number
+        self._sample_rate = sonar_settings.sample_rate
+        self._ping_start = sonar_settings.frame.time
+        if next_offset_record is not None:
+            self._next_offset, next_sonar_settings = next_offset_record
+            self._next_ping_start = next_sonar_settings.frame.time
+        else:
+            self._next_offset = sys.maxsize
+            self._next_ping_start = datetime.max
 
     def __str__(self) -> str:
-        return "<Ping %i>" % self.sonar_settings.ping_number
+        return f"<Ping {self.ping_number}>"
+
+    @property
+    def ping_number(self) -> int:
+        return self._ping_number
+
+    @property
+    def configuration(self) -> records.Configuration:
+        """Return the 7001 record, which is shared for all pings in a file"""
+        return self._reader.configuration
+
+    @cached_property
+    def position_set(self) -> List[records.Position]:
+        """ Returns all 1003 records timestamped within this ping. """
+        return cast(List[records.Position], self._read_records(1003))
+
+    @cached_property
+    def roll_pitch_heave_set(self) -> List[records.RollPitchHeave]:
+        """ Returns all 1012 records timestamped within this ping. """
+        return cast(List[records.RollPitchHeave], self._read_records(1012))
+
+    @cached_property
+    def heading_set(self) -> List[records.Heading]:
+        """ Returns all 1013 records timestamped within this ping. """
+        return cast(List[records.Heading], self._read_records(1013))
+
+    @cached_property
+    def beam_geometry(self) -> Optional[records.BeamGeometry]:
+        """ Returns 7004 record """
+        return cast(Optional[records.BeamGeometry], self._read_record(7004))
+
+    @cached_property
+    def tvg(self) -> Optional[records.TVG]:
+        """ Returns 7010 record """
+        return cast(Optional[records.TVG], self._read_record(7010))
+
+    @cached_property
+    def has_beamformed(self) -> bool:
+        """ Checks if the ping has 7018 data without reading it. """
+        return (
+            self._reader.get_first_offset(7018, self._offset, self._next_offset)
+            is not None
+        )
+
+    @cached_property
+    def beamformed(self) -> Optional[records.Beamformed]:
+        """ Returns 7018 record """
+        return cast(Optional[records.Beamformed], self._read_record(7018))
+
+    @cached_property
+    def has_raw_iq(self) -> bool:
+        """ Checks if the ping has 7038 data without reading it. """
+        return (
+            self._reader.get_first_offset(7038, self._offset, self._next_offset)
+            is not None
+        )
+
+    @cached_property
+    def raw_iq(self) -> Optional[records.RawIQ]:
+        """ Returns 7038 record """
+        return cast(Optional[records.RawIQ], self._read_record(7038))
+
+    @cached_property
+    def gps_position(self) -> geopy.Point:
+        lat = self.position_set[0].latitude * 180 / np.pi
+        long = self.position_set[0].longitude * 180 / np.pi
+        return geopy.Point(lat, long)
+
+    def receiver_motion_for_sample(
+        self, sample: int
+    ) -> Tuple[records.RollPitchHeave, records.Heading]:
+        """ Find the most appropriate motion data for a sample based on time """
+        time = self._ping_start + timedelta(seconds=sample / self._sample_rate)
+        rph_index = min(
+            bisect.bisect_left([m.frame.time for m in self.roll_pitch_heave_set], time),
+            len(self.roll_pitch_heave_set) - 1,
+        )
+        heading_index = min(
+            bisect.bisect_left([m.frame.time for m in self.heading_set], time),
+            len(self.heading_set) - 1,
+        )
+        return self.roll_pitch_heave_set[rph_index], self.heading_set[heading_index]
 
     def minimize_memory(self) -> None:
         """
         Clears all memory-heavy properties.
         Retains offsets for easy reloading.
         """
-        for key in self.minimizable_properties:
+        for key in "beamformed", "tvg", "beam_geometry", "raw_iq":
             if key in self.__dict__:
                 del self.__dict__[key]
 
-    def _get_single_associated_record(self, record_type: int):
-        """
-        Read a record associated with the ping. The requested record must:
-        - Be the only of its type for the ping
-        - Be located in the file between this ping's 7000 record and the next
-          ping' 7000 record.
-        """
-        offset = self._offset_map[record_type]
-        if offset is None:
-            return None
-        record = self._manager.read_record(record_type, offset)
-
-        # If record contains ping number, we double-check validity
-        if hasattr(record, "header") and "ping_number" in record.header:
-            assert record.header["ping_number"] == self.ping_number
-        elif hasattr(record, "ping_number"):
-            assert record.ping_number == self.ping_number
-
+    def _read_record(self, record_type: int) -> Optional[records.BaseRecord]:
+        record = self._reader.read_first_record(
+            record_type, self._offset, self._next_offset
+        )
+        if record is not None:
+            ping_number = self.ping_number
+            assert getattr(record, "ping_number", ping_number) == ping_number
         return record
 
-    @cached_property
-    def position_set(self) -> List[records.Position]:
-        """ Returns all 1003 records timestamped within this ping. """
-        return self._manager.get_records_during_ping(
-            1003, self.sonar_settings.frame.time, self.next_ping_start, self._own_offset
+    def _read_records(self, record_type: int) -> List[records.BaseRecord]:
+        return self._reader.read_records_during_ping(
+            record_type, self._ping_start, self._next_ping_start, self._offset
         )
-
-    @cached_property
-    def roll_pitch_heave_set(self) -> List[records.RollPitchHeave]:
-        """ Returns all 1012 records timestamped within this ping. """
-        return self._manager.get_records_during_ping(
-            1012, self.sonar_settings.frame.time, self.next_ping_start, self._own_offset
-        )
-
-    @cached_property
-    def heading_set(self) -> List[records.Heading]:
-        """ Returns all 1013 records timestamped within this ping. """
-        return self._manager.get_records_during_ping(
-            1013, self.sonar_settings.frame.time, self.next_ping_start, self._own_offset
-        )
-
-    @cached_property
-    def configuration(self) -> records.Configuration:
-        """ Returns the 7001 record, which is shared for all pings in a file """
-        return self._manager.get_configuration_record()
-
-    @cached_property
-    def beam_geometry(self) -> Optional[records.BeamGeometry]:
-        """ Returns 7004 record """
-        return self._get_single_associated_record(7004)
-
-    @cached_property
-    def tvg(self) -> Optional[records.TVG]:
-        """ Returns 7010 record """
-        return self._get_single_associated_record(7010)
-
-    @cached_property
-    def has_beamformed(self) -> bool:
-        """ Checks if the ping has 7018 data without reading it. """
-        return self._offset_map[7018] is not None
-
-    @cached_property
-    def beamformed(self) -> Optional[records.Beamformed]:
-        """ Returns 7018 record """
-        return self._get_single_associated_record(7018)
-
-    @cached_property
-    def has_raw_iq(self) -> bool:
-        """ Checks if the ping has 7038 data without reading it. """
-        return self._offset_map[7038] is not None
-
-    @cached_property
-    def raw_iq(self) -> Optional[records.RawIQ]:
-        """ Returns 7038 record """
-        return self._get_single_associated_record(7038)
-
-    @cached_property
-    def gps_position(self):
-        lat = self.position_set[0].latitude * 180 / np.pi
-        long = self.position_set[0].longitude * 180 / np.pi
-        return geopy.Point(lat, long)
-
-    def receiver_motion_for_sample(self, sample: int):
-        """ Find the most appropriate motion data for a sample based on time """
-        time = self.sonar_settings.frame.time + timedelta(
-            seconds=sample / self.sonar_settings.sample_rate
-        )
-        max_rph_idx = len(self.roll_pitch_heave_set) - 1
-        max_h_idx = len(self.heading_set) - 1
-        rph_index = np.min(
-            [
-                np.searchsorted(
-                    [m.frame.time for m in self.roll_pitch_heave_set], time
-                ),
-                max_rph_idx,
-            ]
-        )
-        heading_index = np.min(
-            [np.searchsorted([m.frame.time for m in self.heading_set], time), max_h_idx]
-        )
-        return self.roll_pitch_heave_set[rph_index], self.heading_set[heading_index]
-
-
-# %%
-class PingType(Enum):
-    """ Kinds of pings based on what data they have available """
-
-    BEAMFORMED = 1
-    IQ = 2
-    ANY = 3
 
 
 class PingDataset:
@@ -370,43 +368,30 @@ class PingDataset:
     Provides random access into pings in a file with minimal overhead.
     """
 
-    def __init__(self, filename, include: PingType = PingType.ANY):
+    def __init__(self, filename: str, include: PingType = PingType.ANY):
         """
         if include argument is not ANY, pings will be filtered.
         """
-        manager = Manager7k(filename)
-        self.filename = filename
-
-        pings = manager.get_pings()
-
-        if include == PingType.BEAMFORMED:
-            self.pings = [p for p in pings if p.has_beamformed]
-        elif include == PingType.IQ:
-            self.pings = [p for p in pings if p.has_raw_iq]
-        elif include == PingType.ANY:
-            self.pings = pings
-        else:
-            raise NotImplementedError("Encountered unknown PingType: %s" % str(include))
-
+        self.pings = list(S7KFileReader(filename).iter_pings(include))
         self.__ping_numbers = [p.ping_number for p in self.pings]
 
     @property
-    def ping_numbers(self):
+    def ping_numbers(self) -> List[int]:
         return self.__ping_numbers
 
-    def minimize_memory(self):
+    def minimize_memory(self) -> None:
         for p in self.pings:
             p.minimize_memory()
 
     def __len__(self) -> int:
         return len(self.pings)
 
-    def index_of(self, ping_number: int):
+    def index_of(self, ping_number: int) -> int:
         return self.__ping_numbers.index(ping_number)
 
     def get_by_number(
-        self, ping_number: int, default: Optional[int] = None
-    ) -> Union[Ping, None]:
+        self, ping_number: int, default: Optional[Ping] = None
+    ) -> Optional[Ping]:
         if not isinstance(ping_number, int):
             raise TypeError("Ping number must be an integer")
         try:
@@ -415,7 +400,7 @@ class PingDataset:
             return default
         return self.pings[ping_index]
 
-    def __getitem__(self, index: Union[slice, int]) -> Union[Ping, List[Ping]]:
+    def __getitem__(self, index: Union[int, slice]) -> Union[Ping, List[Ping]]:
         return self.pings[index]
 
 

--- a/pyread7k/_utils.py
+++ b/pyread7k/_utils.py
@@ -1,5 +1,9 @@
+import collections
 import csv
+import functools
 import io
+import itertools as it
+from typing import Iterable, Iterator, Tuple, TypeVar
 
 from . import records
 from ._datarecord import record as _record
@@ -14,6 +18,30 @@ __all__ = [
     "read_records",
     "export_catalog",
 ]
+
+
+T = TypeVar("T")
+
+
+def window(seq: Iterable[T], n: int) -> Iterator[Tuple[T, ...]]:
+    """Return a sliding window of width n over data from the iterable
+    s -> (s0,s1,...s[n-1]), (s1,s2,...,sn), ...
+    """
+    iterator = iter(seq)
+    q = collections.deque(it.islice(iterator, n), maxlen=n)
+    if len(q) == n:
+        yield tuple(q)
+    for elem in iterator:
+        q.append(elem)
+        yield tuple(q)
+
+
+def cached_property(func):
+    """
+    Fix functools.cached_property to preserve docstrings and name.
+    Note that it does not properly preserve type hints!
+    """
+    return functools.update_wrapper(functools.cached_property(func), func)
 
 
 def read_file_header(source: io.RawIOBase) -> FileHeader:


### PR DESCRIPTION
This is a rather extensive refactoring of the `_ping` module. The main goal is to provide a common interface for reading s7k records and pings, decoupled from the underlying storage. This way the same interface can be implemented by different storage backends, e.g. [TileDB](https://github.com/TileDB-Inc/pyread7k/commit/7ee71eaa92ab88d50926c903701ea5fe569c7447#diff-4691d3be774fc64d26fb9eef8271423c8e842517ab51065e3b4d417395eb5308R113).

List of main changes:
- Rename `Manager7k` to `S7KFileReader`, extract a `S7KReader` base abstract class from it and re-export them from `pyread7k.__init__` 
  - Move the bulk of the `PingDataset.__init__` logic to a new `S7KReader.iter_pings()` method
  - Change `file_catalog` from attribute to a `cached_property`
  - Add a new `file_header` `cached_property`
  - Rename `get_configuration_record` to `configuration` and make it a `cached_property`
- Other changes: 
  - Simplify `get_records_during_ping`
  - Replace `np.searchsorted` with `bisect` for list inputs
  - Drop `LazyMap` and custom `cached_property` classes
  - Add missing typing annotations and casts

This PR should be fully backwards compatible in terms of the public API; if not let me know!