### PR TITLE
Fix records set of last ping in s7k file. Closes #24

### DIFF
--- a/pyread7k/_datarecord.py
+++ b/pyread7k/_datarecord.py
@@ -393,7 +393,7 @@ class _DataRecord7028(DataRecord):
 
         # Pre-read all intensities into linear array for speed
         snippet_type = elemT.u32 if rth["flags"] & 1 == 1 else elemT.u16
-        snippet_block = DataBlock((elemD_("intensity", snippet_type), ))
+        snippet_block = DataBlock((elemD_("intensity", snippet_type),))
         snippet_lengths = rd["snippet_end"] - rd["snippet_start"]
         all_intensities = snippet_block.read_dense(source, int(snippet_lengths.sum()))
 
@@ -401,10 +401,12 @@ class _DataRecord7028(DataRecord):
         offset = 0
         intensities = []
         for snippet_length in snippet_lengths:
-            intensities.append(all_intensities[offset:offset + snippet_length])
+            intensities.append(all_intensities[offset : offset + snippet_length])
             offset += snippet_length
 
-        return records.SnippetData(**rth, bottom_detections=rd, intensities=intensities, frame=drf)
+        return records.SnippetData(
+            **rth, bottom_detections=rd, intensities=intensities, frame=drf
+        )
 
 
 class _DataRecord7038(DataRecord):
@@ -552,12 +554,14 @@ class _DataRecord1008(DataRecord):
     """ Depth """
 
     _record_type_id = 1008
-    _block_rth = DataBlock((
-        elemD_("depth_descriptor", elemT.u8),
-        elemD_("correction_flag", elemT.u8),
-        elemD_(None, elemT.u16),  # Reserved
-        elemD_("depth", elemT.f32),
-    ))
+    _block_rth = DataBlock(
+        (
+            elemD_("depth_descriptor", elemT.u8),
+            elemD_("correction_flag", elemT.u8),
+            elemD_(None, elemT.u16),  # Reserved
+            elemD_("depth", elemT.f32),
+        )
+    )
 
     def _read(
         self, source: io.RawIOBase, drf: records.DataRecordFrame, start_offset: int
@@ -585,11 +589,13 @@ class _DataRecord1018(DataRecord):
     """ Velocity """
 
     _record_type_id = 1018
-    _block_rth = DataBlock((
-        elemD_("velocity_x", elemT.f32),
-        elemD_("velocity_y", elemT.f32),
-        elemD_("velocity_z", elemT.f32),
-    ))
+    _block_rth = DataBlock(
+        (
+            elemD_("velocity_x", elemT.f32),
+            elemD_("velocity_y", elemT.f32),
+            elemD_("velocity_z", elemT.f32),
+        )
+    )
 
     def _read(
         self, source: io.RawIOBase, drf: records.DataRecordFrame, start_offset: int

--- a/pyread7k/_ping.py
+++ b/pyread7k/_ping.py
@@ -573,3 +573,11 @@ class FolderDataset(ConcatDataset):
 
             ds.pings = ds_pings
             self.cum_lengths.append(ds_count)
+
+        # Fix for issue #24
+        for i in range(1, len(self.datasets)):
+            # Get timestamp of first ping in subsequent dataset
+            new_time = self.datasets[i][0].sonar_settings.frame.time
+
+            # Update last ping of previous dataset
+            self.datasets[i - 1][-1]._next_ping_start = new_time

--- a/pyread7k/records.py
+++ b/pyread7k/records.py
@@ -103,12 +103,12 @@ class Position(BaseRecord):
 @dataclass
 class Depth(BaseRecord):
     """ Record 1008 Water depth """
-    record_type : int = field(default=1008, init=False)
 
-    depth_descriptor : int
-    correction_flag : int
-    depth : float
+    record_type: int = field(default=1008, init=False)
 
+    depth_descriptor: int
+    correction_flag: int
+    depth: float
 
 
 @dataclass
@@ -140,9 +140,9 @@ class Velocity(BaseRecord):
 
     record_type: int = field(default=1018, init=False)
 
-    velocity_x : float
-    velocity_y : float
-    velocity_z : float
+    velocity_x: float
+    velocity_y: float
+    velocity_z: float
 
 
 @dataclass
@@ -265,12 +265,15 @@ class Beamformed(BaseRecord):
     amplitudes: np.ndarray
     phases: np.ndarray
 
+
 class SnippetControlFlag(Enum):
     """ Flag for 7028 Snippet data """
+
     AUTOMATIC_SNIPPET_WINDOW_USED = 0
     QUALITY_FILTER_ENABLED = 1
     MINIMUM_WINDOW_SIZE_REQUIRED = 2
     MAXIMIUM_WINDOW_SIZE_REQUIRED = 3
+
 
 @dataclass
 class SnippetData(BaseRecord):
@@ -278,20 +281,21 @@ class SnippetData(BaseRecord):
     Record 7028
     Contains seabed detections for bathymetry data
     """
+
     record_type: int = field(default=7028, init=False)
 
-    sonar_id : int
-    ping_number : int
-    multi_ping_sequence : int
-    detection_count : int
-    error_flag : int
-    control_flags : SnippetControlFlag
-    flags : int
+    sonar_id: int
+    ping_number: int
+    multi_ping_sequence: int
+    detection_count: int
+    error_flag: int
+    control_flags: SnippetControlFlag
+    flags: int
 
-    bottom_detections : np.ndarray
+    bottom_detections: np.ndarray
 
     # Intensity snippet from beamformed data for each detection
-    intensities : list[np.ndarray]
+    intensities: list[np.ndarray]
 
 
 @dataclass

--- a/test/test_ping_functions.py
+++ b/test/test_ping_functions.py
@@ -20,26 +20,31 @@ def test_filedataaset_valid_index(filedataset: FileDataset):
     assert isinstance(filedataset[0], Ping)
 
 
-@pytest.mark.parametrize("ping_number,default,expected,raises", [
-    (123123123, 1, int, does_not_raise()),
-    (123123123, "weird but works", str, does_not_raise()),
-    (123123123, "weird but works", int, pytest.raises(AssertionError)),
-])
 class TestFiledatasetFunctions:
     """Grouped FileDataset tests"""
     @pytest.fixture
     def dataset(self):
         return FileDataset(bf_filepath, include=PingType.BEAMFORMED)
 
-    def test_filedataset_get_by_number(self, ping_number, default, expected,
+    @pytest.mark.parametrize("ping_number,default,expected,raises", [
+        (123123123, 1, int, does_not_raise()),
+        (123123123, "weird but works", str, does_not_raise()),
+        (123123123, "weird but works", int, pytest.raises(AssertionError)),
+        ("not a ping", None, int, pytest.raises(TypeError)),
+    ])
+    def test_filedataset_get_by_number_input_handling(self, ping_number, default, expected,
                                        raises, dataset):
         with raises:
             assert isinstance(dataset.get_by_number(ping_number, default),
                               expected)
 
+    def test_filedataset_get_by_number(self, dataset):
+        ping_numbers = dataset.ping_numbers
+        for pn in ping_numbers:
+            assert isinstance(dataset.get_by_number(pn), Ping)
 
-def test_filedataset_compare_indexing_methods(filedataset: FileDataset):
-    first_ping_by_index = filedataset[0]
-    first_ping_by_number = filedataset.get_by_number(
-        first_ping_by_index.sonar_settings.ping_number)
-    assert first_ping_by_index == first_ping_by_number
+    def test_filedataset_index_of(self, dataset):
+        for p in dataset:
+            ping_number = int(p.sonar_settings.ping_number)
+            assert isinstance(dataset.index_of(ping_number), int)
+


### PR DESCRIPTION
This merge fixes the issue of too many records sets associated with the last ping in an s7k files. The fix applies only to the FolderDataset datastructure, as it already assumes that the files are part of a single recording.