### PR TITLE
Optimize disk access

### DIFF
--- a/pyread7k/records.py
+++ b/pyread7k/records.py
@@ -484,7 +484,6 @@ class FileHeader(BaseRecord):
 class FileCatalog(BaseRecord):
     """Record 7300.
     7k file catalog record, placed at the end of log files.
-    record_type : int = field(default=7300, init=False)
 
     The file catalog contains one entry for each record in the log file,
     including the 7200 file header record, but excluding the 7300 file catalog


### PR DESCRIPTION
These changes reduce number of disk reads by half by reading into a buffer before parsing records.
For workloads with latency-dominated disks, such as reading a file over a network, this will translate into double reading speed.